### PR TITLE
Fix JWT payload decoding for unpadded tokens

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,9 @@ module.exports = function (RED) {
     try {
       const parts = token.split('.');
       if (parts.length < 2) return null;
-      const payload = Buffer.from(parts[1].replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8');
+      let b64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+      b64 += '='.repeat((4 - (b64.length % 4)) % 4);
+      const payload = Buffer.from(b64, 'base64').toString('utf8');
       return JSON.parse(payload);
     } catch (e) {
       return null;

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -26,6 +26,28 @@ describe('node-red-dashboard-2-oauth2-auth plugin', () => {
     expect(msg._client.proxy.jwt.name).to.equal('Alice');
   });
 
+  it('decodes JWT payloads that require one padding character', () => {
+    const hooks = setup({ allowedJwtClaims: ['a'] });
+    const payload = { a: '' };
+    const token = 'x.' + Buffer.from(JSON.stringify(payload)).toString('base64url') + '.y';
+    const conn = { request: { headers: { 'x-forwarded-access-token': token } } };
+
+    const msg = hooks.onAddConnectionCredentials(conn, {});
+
+    expect(msg._client.proxy.jwt.a).to.equal('');
+  });
+
+  it('decodes JWT payloads that require two padding characters', () => {
+    const hooks = setup({ allowedJwtClaims: ['abc'] });
+    const payload = { abc: '' };
+    const token = 'x.' + Buffer.from(JSON.stringify(payload)).toString('base64url') + '.y';
+    const conn = { request: { headers: { 'x-forwarded-access-token': token } } };
+
+    const msg = hooks.onAddConnectionCredentials(conn, {});
+
+    expect(msg._client.proxy.jwt.abc).to.equal('');
+  });
+
   it('onCanSaveInStore blocks messages with socketId', () => {
     const hooks = setup();
 


### PR DESCRIPTION
## Summary
- pad JWT payload segment before base64 decoding
- test decoding of JWTs requiring padding

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb47c2b114832a893a90994ac20cd3