### PR TITLE
Add Traefik example configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ Restart Node-RED after installation.
 }
 ```
 
+### Traefik example
+
+See [examples/traefik](./examples/traefik) for a Docker Compose configuration that runs Node-RED Dashboard 2 behind Traefik and `oauth2-proxy`.
+
 ---
 
 ## 📜 License

--- a/examples/traefik/README.md
+++ b/examples/traefik/README.md
@@ -1,0 +1,11 @@
+# Traefik example
+
+This directory contains a minimal [Docker Compose](docker-compose.yml) setup showing how to run Node-RED Dashboard 2 with `oauth2-proxy` behind [Traefik](https://traefik.io/).
+
+## Usage
+
+```bash
+docker compose up
+```
+
+Traefik exposes Node-RED on port **8080** and protects it using `oauth2-proxy`. Replace the placeholder OAuth client credentials in the compose file before running.

--- a/examples/traefik/docker-compose.yml
+++ b/examples/traefik/docker-compose.yml
@@ -1,0 +1,36 @@
+version: "3"
+
+services:
+  traefik:
+    image: traefik:v3.0
+    command:
+      - --api.insecure=true
+      - --providers.docker=true
+      - --entryPoints.web.address=:80
+    ports:
+      - "8080:80"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  oauth2-proxy:
+    image: quay.io/oauth2-proxy/oauth2-proxy:v7.5.1
+    command:
+      - --provider=github
+      - --http-address=0.0.0.0:4180
+      - --upstream=http://nodered:1880
+      - --cookie-secret=00000000000000000000000000000000
+      - --set-xauthrequest=true
+    environment:
+      - OAUTH2_PROXY_CLIENT_ID=changeme
+      - OAUTH2_PROXY_CLIENT_SECRET=changeme
+
+  nodered:
+    image: nodered/node-red:latest
+    labels:
+      - "traefik.http.routers.nodered.rule=PathPrefix(`/`)"
+      - "traefik.http.routers.nodered.entrypoints=web"
+      - "traefik.http.routers.nodered.middlewares=oauth2-auth"
+      - "traefik.http.services.nodered.loadbalancer.server.port=1880"
+      - "traefik.http.middlewares.oauth2-auth.forwardauth.address=http://oauth2-proxy:4180/auth"
+      - "traefik.http.middlewares.oauth2-auth.forwardauth.trustForwardHeader=true"
+      - "traefik.http.middlewares.oauth2-auth.forwardauth.authResponseHeaders=X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Preferred-Username"


### PR DESCRIPTION
## Summary
- add docker-compose example showcasing Traefik with oauth2-proxy and Node-RED
- document example and reference from README

## Testing
- `python3 - <<'PY'
import yaml, sys
with open('examples/traefik/docker-compose.yml') as f:
    yaml.safe_load(f)
print('YAML loaded successfully')
PY`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5e4eb26d0832aac08c5bfbef6a3b6