### PR TITLE
Add authentication guard and document configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It extracts user information from the HTTP headers added by oauth2-proxy and mak
 - Supports common oauth2-proxy headers:
   - `x-auth-request-user`, `x-forwarded-user`
   - `x-auth-request-email`, `x-forwarded-email`
-  - `x-auth-request-preferred-username`
+  - `x-auth-request-preferred-username`, `x-forwarded-preferred-username`
 - Adds `socketId` and `socketIp` to help trace individual client sessions
 - Prevents unauthenticated users from interacting with flows (configurable in hook `onIsValidConnection`)
 
@@ -54,6 +54,34 @@ Restart Node-RED after installation.
   }
 }
 ```
+
+---
+
+## ⚙️ Configuration (optional)
+
+All behaviour can be tuned from your `settings.js` file:
+
+```js
+module.exports = {
+  plugins: {
+    'node-red-dashboard-2-oauth2-auth': {
+      // Set to false to allow unauthenticated access
+      requireAuth: true,
+      // Headers (case-insensitive) that must be present when requireAuth is true
+      requiredAuthHeaders: [
+        'x-auth-request-user',
+        'x-forwarded-user'
+      ],
+      // Where to attach the proxy data inside msg._client
+      clientPath: ['proxy'],
+      // Mirror data into msg.headers as well
+      mirrorToMsgHeaders: false
+    }
+  }
+};
+```
+
+All header names are normalised to lowercase and you can pass single values or arrays in the configuration.
 
 ---
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,20 @@
 module.exports = function (RED) {
   const pluginId = 'node-red-dashboard-2-oauth2-auth';
 
+  function toArray(value) {
+    if (Array.isArray(value)) return value;
+    if (value === undefined || value === null) return [];
+    return [value];
+  }
+
+  function normaliseHeaderKeys(allHeaders) {
+    const lower = {};
+    Object.keys(allHeaders || {}).forEach(k => {
+      lower[k.toLowerCase()] = allHeaders[k];
+    });
+    return lower;
+  }
+
   function decodeJwtNoVerify(token) {
     try {
       const parts = token.split('.');
@@ -16,6 +30,9 @@ module.exports = function (RED) {
   const defaults = {
     // Only these headers (case-insensitive) are exposed to flows
     allowedHeaders: [
+      'x-auth-request-user',
+      'x-auth-request-email',
+      'x-auth-request-preferred-username',
       'x-forwarded-user',
       'x-forwarded-email',
       'x-forwarded-preferred-username',
@@ -43,28 +60,53 @@ module.exports = function (RED) {
     // Attach under this path in msg._client
     clientPath: ['proxy'],
     // Whether to also mirror into msg.headers.* (false by default to avoid bloat)
-    mirrorToMsgHeaders: false
+    mirrorToMsgHeaders: false,
+    // Require at least one of these headers to allow a connection (when requireAuth is true)
+    requiredAuthHeaders: [
+      'x-auth-request-user',
+      'x-auth-request-email',
+      'x-auth-request-preferred-username',
+      'x-forwarded-user',
+      'x-forwarded-email',
+      'x-forwarded-preferred-username'
+    ],
+    requireAuth: true
   };
 
   // Helper to read config from settings.js
   function readSettings() {
     const userCfg = RED?.settings?.plugins?.[pluginId] || {};
+    const allowedHeaders = userCfg.allowedHeaders
+      ? toArray(userCfg.allowedHeaders)
+      : defaults.allowedHeaders;
+    const redactedHeaders = userCfg.redactedHeaders
+      ? toArray(userCfg.redactedHeaders)
+      : defaults.redactedHeaders;
+    const allowedJwtClaims = userCfg.allowedJwtClaims
+      ? toArray(userCfg.allowedJwtClaims)
+      : defaults.allowedJwtClaims;
+    const clientPath = userCfg.clientPath != null
+      ? toArray(userCfg.clientPath)
+      : defaults.clientPath;
+    const requiredAuthHeaders = userCfg.requiredAuthHeaders
+      ? toArray(userCfg.requiredAuthHeaders)
+      : defaults.requiredAuthHeaders;
     return {
       ...defaults,
       ...userCfg,
-      allowedHeaders: (userCfg.allowedHeaders || defaults.allowedHeaders).map(h => String(h).toLowerCase()),
-      redactedHeaders: (userCfg.redactedHeaders || defaults.redactedHeaders).map(h => String(h).toLowerCase()),
-      allowedJwtClaims: (userCfg.allowedJwtClaims || defaults.allowedJwtClaims)
+      allowedHeaders: allowedHeaders.map(h => String(h).toLowerCase()),
+      redactedHeaders: redactedHeaders.map(h => String(h).toLowerCase()),
+      allowedJwtClaims,
+      clientPath: clientPath.map(part => String(part)),
+      requiredAuthHeaders: requiredAuthHeaders.map(h => String(h).toLowerCase()),
+      requireAuth: userCfg.requireAuth != null ? Boolean(userCfg.requireAuth) : defaults.requireAuth
     };
   }
 
   function pickHeaders(allHeaders, cfg) {
     const out = {};
     // Normalise keys to lowercase
-    const lower = {};
-    Object.keys(allHeaders || {}).forEach(k => {
-      lower[k.toLowerCase()] = allHeaders[k];
-    });
+    const lower = normaliseHeaderKeys(allHeaders);
 
     cfg.allowedHeaders.forEach(h => {
       if (lower[h] != null) {
@@ -173,6 +215,26 @@ module.exports = function (RED) {
           msg._client[pluginId] = { error: String((e && e.message) || e) };
         }
         return msg;
+      },
+      onIsValidConnection: (conn) => {
+        try {
+          const cfg = readSettings();
+          if (!cfg.requireAuth) {
+            return true;
+          }
+          const lower = normaliseHeaderKeys(conn?.request?.headers || {});
+          return cfg.requiredAuthHeaders.some(h => {
+            const value = lower[h];
+            if (value === undefined || value === null) return false;
+            if (Array.isArray(value)) {
+              return value.some(v => String(v ?? '').trim() !== '');
+            }
+            return String(value ?? '').trim() !== '';
+          });
+        } catch (e) {
+          // Fail open if configuration parsing fails
+          return true;
+        }
       },
 
       // Optional: avoid storing per-client messages containing socket-bound targeting

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -32,4 +32,24 @@ describe('node-red-dashboard-2-oauth2-auth plugin', () => {
     expect(hooks.onCanSaveInStore({ _client: { socketId: 'abc' } })).to.be.false;
     expect(hooks.onCanSaveInStore({})).to.be.true;
   });
+
+  it('onIsValidConnection enforces authentication by default', () => {
+    const hooks = setup();
+
+    expect(hooks.onIsValidConnection({ request: { headers: {} } })).to.be.false;
+    expect(
+      hooks.onIsValidConnection({ request: { headers: { 'X-Auth-Request-User': 'alice' } } })
+    ).to.be.true;
+  });
+
+  it('onIsValidConnection can be configured via settings', () => {
+    const hooks = setup({ requireAuth: false });
+    expect(hooks.onIsValidConnection({ request: { headers: {} } })).to.be.true;
+
+    const customHooks = setup({ requiredAuthHeaders: 'x-custom-user' });
+    expect(customHooks.onIsValidConnection({ request: { headers: {} } })).to.be.false;
+    expect(
+      customHooks.onIsValidConnection({ request: { headers: { 'X-Custom-User': 'bob' } } })
+    ).to.be.true;
+  });
 });


### PR DESCRIPTION
## Summary
- add a configurable `onIsValidConnection` hook that blocks unauthenticated websocket clients
- normalise plugin settings input, expand default oauth2-proxy header support, and expose new auth options
- document configuration capabilities and cover the new behaviour with unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1198ce2f0832abd503152241673e0